### PR TITLE
Slot booking engine with QR generation

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -13,6 +13,13 @@ import '../../features/auth/providers/auth_provider.dart';
 import '../../features/dashboard/screens/home_screen.dart';
 import '../../features/dashboard/screens/quota_dashboard_screen.dart';
 import '../../features/map/screens/map_screen.dart';
+import '../../features/map/models/station_model.dart';
+import '../../features/booking/screens/station_booking_screen.dart';
+import '../../features/booking/screens/booking_confirmation_screen.dart';
+import '../../features/booking/screens/booking_detail_screen.dart';
+import '../../features/booking/screens/my_bookings_screen.dart';
+import '../../features/booking/models/booking_model.dart';
+import '../constants/app_colors.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
@@ -22,63 +29,27 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       final isLoggedIn = ref.read(authStateProvider).valueOrNull != null;
       final currentPath = state.uri.path;
 
-      // Public routes that don't require auth
-      const publicRoutes = [
-        '/splash',
-        '/welcome',
-        '/login',
-        '/register',
-        '/forgot-password',
-      ];
-
-      // Routes that are part of registration flow
+      const publicRoutes = ['/splash', '/welcome', '/login', '/register', '/forgot-password'];
       const registrationRoutes = ['/add-vehicle', '/register'];
 
       final isPublicRoute = publicRoutes.contains(currentPath);
       final isRegistrationRoute = registrationRoutes.contains(currentPath);
 
-      // Don't redirect if on splash (it handles its own navigation)
       if (currentPath == '/splash') return null;
-
-      // Not logged in trying to access protected route
-      if (!isLoggedIn && !isPublicRoute) {
-        return '/welcome';
-      }
-
-      // Logged in trying to access auth screens (welcome/login/register)
-      if (isLoggedIn &&
-          isPublicRoute &&
-          currentPath != '/splash' &&
-          !isRegistrationRoute) {
-        return '/home';
-      }
+      if (!isLoggedIn && !isPublicRoute) return '/welcome';
+      if (isLoggedIn && isPublicRoute && currentPath != '/splash' && !isRegistrationRoute) return '/home';
 
       return null;
     },
     routes: [
-      GoRoute(
-        path: '/splash',
-        builder: (context, state) => const SplashScreen(),
-      ),
-      GoRoute(
-        path: '/welcome',
-        builder: (context, state) => const WelcomeScreen(),
-      ),
-      GoRoute(
-        path: '/login',
-        builder: (context, state) => const LoginScreen(),
-      ),
-      GoRoute(
-        path: '/register',
-        builder: (context, state) => const RegisterScreen(),
-      ),
-      GoRoute(
-        path: '/forgot-password',
-        builder: (context, state) => const ForgotPasswordScreen(),
-      ),
+      GoRoute(path: '/splash', builder: (_, state) => const SplashScreen()),
+      GoRoute(path: '/welcome', builder: (_, state) => const WelcomeScreen()),
+      GoRoute(path: '/login', builder: (_, state) => const LoginScreen()),
+      GoRoute(path: '/register', builder: (_, state) => const RegisterScreen()),
+      GoRoute(path: '/forgot-password', builder: (_, state) => const ForgotPasswordScreen()),
       GoRoute(
         path: '/add-vehicle',
-        builder: (context, state) {
+        builder: (_, state) {
           final data = state.extra as Map<String, dynamic>;
           return VehicleRegistrationScreen(
             uid: data['uid'] as String,
@@ -86,31 +57,102 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           );
         },
       ),
+
+      // Main app with bottom nav
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) {
+          return _MainShell(navigationShell: navigationShell);
+        },
+        branches: [
+          StatefulShellBranch(routes: [
+            GoRoute(path: '/home', builder: (_, state) => const HomeScreen()),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(path: '/map', builder: (_, state) => const MapScreen()),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(path: '/my-bookings', builder: (_, state) => const MyBookingsScreen()),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(path: '/profile', builder: (_, state) => const ProfileScreen()),
+          ]),
+        ],
+      ),
+
+      // Screens that push on top of the nav bar
+      GoRoute(path: '/quota', builder: (_, state) => const QuotaDashboardScreen()),
       GoRoute(
-        path: '/home',
-        builder: (context, state) => const HomeScreen(),
+        path: '/book-station',
+        builder: (_, state) {
+          final station = state.extra as StationModel;
+          return StationBookingScreen(station: station);
+        },
       ),
       GoRoute(
-        path: '/quota',
-        builder: (context, state) => const QuotaDashboardScreen(),
+        path: '/booking-confirmed',
+        builder: (_, state) {
+          final data = state.extra as Map<String, dynamic>;
+          return BookingConfirmationScreen(
+            booking: data['booking'] as BookingModel,
+            slotDuration: data['slotDuration'] as Duration,
+          );
+        },
       ),
       GoRoute(
-        path: '/profile',
-        builder: (context, state) => const ProfileScreen(),
-      ),
-      GoRoute(
-        path: '/map',
-        builder: (context, state) => const MapScreen(),
+        path: '/booking-detail',
+        builder: (_, state) {
+          final booking = state.extra as BookingModel;
+          return BookingDetailScreen(booking: booking);
+        },
       ),
     ],
   );
 });
 
-/// Notifies GoRouter when auth state changes so redirect re-evaluates.
+class _MainShell extends StatelessWidget {
+  final StatefulNavigationShell navigationShell;
+
+  const _MainShell({required this.navigationShell});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: navigationShell,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: navigationShell.currentIndex,
+        onDestinationSelected: (index) => navigationShell.goBranch(index, initialLocation: index == navigationShell.currentIndex),
+        backgroundColor: Colors.white,
+        indicatorColor: AppColors.primary.withValues(alpha: 0.12),
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.home_outlined),
+            selectedIcon: Icon(Icons.home_rounded, color: AppColors.primary),
+            label: 'Home',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.map_outlined),
+            selectedIcon: Icon(Icons.map_rounded, color: AppColors.primary),
+            label: 'Map',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.calendar_today_outlined),
+            selectedIcon: Icon(Icons.calendar_today_rounded, color: AppColors.primary),
+            label: 'Bookings',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.person_outline_rounded),
+            selectedIcon: Icon(Icons.person_rounded, color: AppColors.primary),
+            label: 'Profile',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _RouterRefreshStream extends ChangeNotifier {
   late final ProviderSubscription<AsyncValue<User?>> _subscription;
 
-// Changed to (_, __) again due to avoiding naming conflicts, keeping to standard.
   _RouterRefreshStream(Ref ref) {
     _subscription = ref.listen(authStateProvider, (_, _) => notifyListeners());
   }

--- a/lib/features/auth/screens/profile_screen.dart
+++ b/lib/features/auth/screens/profile_screen.dart
@@ -54,22 +54,25 @@ class ProfileScreen extends ConsumerWidget {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        GestureDetector(
-                          onTap: () => context.pop(),
-                          child: Container(
-                            width: 40,
-                            height: 40,
-                            decoration: BoxDecoration(
-                              color: Colors.white.withValues(alpha: 0.15),
-                              borderRadius: BorderRadius.circular(12),
+                        if (Navigator.of(context).canPop())
+                          GestureDetector(
+                            onTap: () => context.pop(),
+                            child: Container(
+                              width: 40,
+                              height: 40,
+                              decoration: BoxDecoration(
+                                color: Colors.white.withValues(alpha: 0.15),
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              child: const Icon(
+                                Icons.arrow_back_rounded,
+                                color: Colors.white,
+                                size: 20,
+                              ),
                             ),
-                            child: const Icon(
-                              Icons.arrow_back_rounded,
-                              color: Colors.white,
-                              size: 20,
-                            ),
-                          ),
-                        ),
+                          )
+                        else
+                          const SizedBox(width: 40),
                         const Text(
                           'Profile',
                           style: TextStyle(
@@ -268,9 +271,29 @@ class ProfileScreen extends ConsumerWidget {
                             foregroundColor: AppColors.error,
                             side: const BorderSide(color: AppColors.error),
                           ),
-                          onPressed: () async {
-                            await ref.read(authServiceProvider).signOut();
-                            if (context.mounted) context.go('/welcome');
+                          onPressed: () {
+                            showDialog(
+                              context: context,
+                              builder: (ctx) => AlertDialog(
+                                title: const Text('Sign Out?'),
+                                content: const Text('Are you sure you want to sign out of your account?'),
+                                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                                actions: [
+                                  TextButton(
+                                    onPressed: () => Navigator.pop(ctx),
+                                    child: const Text('Cancel', style: TextStyle(color: AppColors.textSecondary)),
+                                  ),
+                                  TextButton(
+                                    onPressed: () async {
+                                      Navigator.pop(ctx);
+                                      await ref.read(authServiceProvider).signOut();
+                                      if (context.mounted) context.go('/welcome');
+                                    },
+                                    child: const Text('Sign Out', style: TextStyle(color: AppColors.error, fontWeight: FontWeight.w600)),
+                                  ),
+                                ],
+                              ),
+                            );
                           },
                           child: const Row(
                             mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/features/auth/screens/vehicle_registration_screen.dart
+++ b/lib/features/auth/screens/vehicle_registration_screen.dart
@@ -89,6 +89,39 @@ class _VehicleRegistrationScreenState
     }
   }
 
+  Future<void> _saveAndGoBack() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
+    try {
+      final vehicle = VehicleModel(
+        id: DateTime.now().millisecondsSinceEpoch.toString(),
+        vehicleNumber: _vehicleNumberController.text.trim().toUpperCase(),
+        chassisNumber: _chassisNumberController.text.trim().toUpperCase(),
+        fuelType: _selectedFuelType,
+        nickname: _nicknameController.text.trim(),
+        createdAt: DateTime.now(),
+      );
+
+      await ref.read(authServiceProvider).addVehicle(uid: widget.uid, vehicle: vehicle);
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Vehicle added successfully!'), backgroundColor: AppColors.success),
+        );
+        context.pop();
+      }
+    } on Exception catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(e.toString().replaceAll('Exception: ', '')), backgroundColor: AppColors.error),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
   void _finish() {
     context.go('/home');
   }
@@ -293,58 +326,61 @@ class _VehicleRegistrationScreenState
                           ],
                         ),
                         const SizedBox(height: 32),
-                        OutlinedButton(
-                          onPressed: _isLoading ? null : _addVehicle,
-                          child: _isLoading
-                              ? const SizedBox(
-                                  height: 20,
-                                  width: 20,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                  ),
-                                )
-                              : Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    const Icon(Icons.add_rounded),
-                                    const SizedBox(width: 8),
-                                    Text(
-                                      _addedVehicles.isEmpty
-                                          ? 'Add Vehicle'
-                                          : 'Add Another Vehicle',
-                                    ),
-                                  ],
-                                ),
-                        ),
-                        if (widget.isFirstTime &&
-                            _addedVehicles.isNotEmpty) ...[
-                          const SizedBox(height: 16),
-                          ElevatedButton(
-                            onPressed: _finish,
-                            child: const Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Text('Continue to Dashboard'),
-                                SizedBox(width: 8),
-                                Icon(Icons.arrow_forward_rounded, size: 20),
-                              ],
-                            ),
-                          ),
-                        ],
-                        if (!widget.isFirstTime) ...[
-                          const SizedBox(height: 16),
-                          ElevatedButton(
+                        if (widget.isFirstTime) ...[
+                          OutlinedButton(
                             onPressed: _isLoading ? null : _addVehicle,
-                            child: const Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Text('Save Vehicle'),
-                                SizedBox(width: 8),
-                                Icon(Icons.check_rounded, size: 20),
-                              ],
-                            ),
+                            child: _isLoading
+                                ? const SizedBox(
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(strokeWidth: 2),
+                                  )
+                                : Row(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      const Icon(Icons.add_rounded),
+                                      const SizedBox(width: 8),
+                                      Text(
+                                        _addedVehicles.isEmpty
+                                            ? 'Add Vehicle'
+                                            : 'Add Another Vehicle',
+                                      ),
+                                    ],
+                                  ),
                           ),
+                          if (_addedVehicles.isNotEmpty) ...[
+                            const SizedBox(height: 16),
+                            ElevatedButton(
+                              onPressed: _finish,
+                              child: const Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text('Continue to Dashboard'),
+                                  SizedBox(width: 8),
+                                  Icon(Icons.arrow_forward_rounded, size: 20),
+                                ],
+                              ),
+                            ),
+                          ],
                         ],
+                        if (!widget.isFirstTime)
+                          ElevatedButton(
+                            onPressed: _isLoading ? null : _saveAndGoBack,
+                            child: _isLoading
+                                ? const SizedBox(
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                                  )
+                                : const Row(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Text('Save Vehicle'),
+                                      SizedBox(width: 8),
+                                      Icon(Icons.check_rounded, size: 20),
+                                    ],
+                                  ),
+                          ),
                         const SizedBox(height: 32),
                       ],
                     ),

--- a/lib/features/booking/models/booking_model.dart
+++ b/lib/features/booking/models/booking_model.dart
@@ -1,0 +1,152 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+enum BookingStatus { upcoming, completed, cancelled, expired, noShow }
+
+class BookingConfig {
+  final int slotDurationMinutes;
+  final int maxVehiclesPerSlot;
+  final int cancelWindowMinutes;
+  final int arrivalWindowMinutes;
+  final int maxBookingsPerVehiclePerDay;
+
+  const BookingConfig({
+    required this.slotDurationMinutes,
+    required this.maxVehiclesPerSlot,
+    required this.cancelWindowMinutes,
+    required this.arrivalWindowMinutes,
+    required this.maxBookingsPerVehiclePerDay,
+  });
+
+  Duration get slotDuration => Duration(minutes: slotDurationMinutes);
+  Duration get cancelWindow => Duration(minutes: cancelWindowMinutes);
+  Duration get arrivalWindow => Duration(minutes: arrivalWindowMinutes);
+
+  factory BookingConfig.fromMap(Map<String, dynamic> map) {
+    return BookingConfig(
+      slotDurationMinutes: (map['slotDurationMinutes'] as num?)?.toInt() ?? 30,
+      maxVehiclesPerSlot: (map['maxVehiclesPerSlot'] as num?)?.toInt() ?? 15,
+      cancelWindowMinutes: (map['cancelWindowMinutes'] as num?)?.toInt() ?? 30,
+      arrivalWindowMinutes: (map['arrivalWindowMinutes'] as num?)?.toInt() ?? 15,
+      maxBookingsPerVehiclePerDay: (map['maxBookingsPerVehiclePerDay'] as num?)?.toInt() ?? 1,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+    'slotDurationMinutes': slotDurationMinutes,
+    'maxVehiclesPerSlot': maxVehiclesPerSlot,
+    'cancelWindowMinutes': cancelWindowMinutes,
+    'arrivalWindowMinutes': arrivalWindowMinutes,
+    'maxBookingsPerVehiclePerDay': maxBookingsPerVehiclePerDay,
+  };
+}
+
+class BookingModel {
+  final String id;
+  final String userId;
+  final String stationId;
+  final String stationName;
+  final String vehicleId;
+  final String vehicleNumber;
+  final String fuelType;
+  final DateTime slotStart;
+  final BookingStatus status;
+  final String qrToken;
+  final bool qrUsed;
+  final String? scannedBy;
+  final DateTime? scannedAt;
+  final DateTime createdAt;
+
+  //a
+  const BookingModel({
+    required this.id,
+    required this.userId,
+    required this.stationId,
+    required this.stationName,
+    required this.vehicleId,
+    required this.vehicleNumber,
+    required this.fuelType,
+    required this.slotStart,
+    required this.status,
+    required this.qrToken,
+    this.qrUsed = false,
+    this.scannedBy,
+    this.scannedAt,
+    required this.createdAt,
+  });
+
+  DateTime slotEnd(Duration slotDuration) => slotStart.add(slotDuration);
+
+  String slotTimeLabel(Duration slotDuration) =>
+    '${_formatTime(slotStart)} - ${_formatTime(slotEnd(slotDuration))}';
+
+  factory BookingModel.fromMap(String id, Map<String, dynamic> map) {
+    return BookingModel(
+      id: id,
+      userId: map['userId'] as String? ?? '',
+      stationId: map['stationId'] as String? ?? '',
+      stationName: map['stationName'] as String? ?? '',
+      vehicleId: map['vehicleId'] as String? ?? '',
+      vehicleNumber: map['vehicleNumber'] as String? ?? '',
+      fuelType: map['fuelType'] as String? ?? '',
+      slotStart: (map['slotStart'] as Timestamp).toDate(),
+      status: _parseStatus(map['status'] as String?),
+      qrToken: map['qrToken'] as String? ?? '',
+      qrUsed: map['qrUsed'] as bool? ?? false,
+      scannedBy: map['scannedBy'] as String?,
+      scannedAt: (map['scannedAt'] as Timestamp?)?.toDate(),
+      createdAt: (map['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+    'userId': userId,
+    'stationId': stationId,
+    'stationName': stationName,
+    'vehicleId': vehicleId,
+    'vehicleNumber': vehicleNumber,
+    'fuelType': fuelType,
+    'slotStart': Timestamp.fromDate(slotStart),
+    'status': status.name,
+    'qrToken': qrToken,
+    'qrUsed': qrUsed,
+    'scannedBy': scannedBy,
+    'scannedAt': scannedAt != null ? Timestamp.fromDate(scannedAt!) : null,
+    'createdAt': Timestamp.fromDate(createdAt),
+  };
+
+  BookingModel copyWith({
+    BookingStatus? status,
+    bool? qrUsed,
+    String? scannedby,
+    DateTime? scannedAt,
+  }) {
+    return BookingModel(
+      id: id,
+      userId: userId,
+      stationId: stationId,
+      stationName: stationName,
+      vehicleId: vehicleId,
+      vehicleNumber: vehicleNumber,
+      fuelType: fuelType,
+      slotStart: slotStart,
+      status: status ?? this.status,
+      qrToken: qrToken,
+      qrUsed: qrUsed ?? this.qrUsed,
+      scannedBy: scannedBy ?? this.scannedBy,
+      scannedAt: scannedAt ?? this.scannedAt,
+      createdAt: createdAt,
+    );
+  }
+
+  static BookingStatus _parseStatus(String? value) {
+    return BookingStatus.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => BookingStatus.upcoming,
+    );
+  }
+
+  static String _formatTime(DateTime dt) =>
+    '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+}
+
+// 

--- a/lib/features/booking/providers/booking_provider.dart
+++ b/lib/features/booking/providers/booking_provider.dart
@@ -1,0 +1,138 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+import '../../auth/providers/auth_provider.dart';
+import '../models/booking_model.dart';
+
+final bookingConfigProvider = FutureProvider<BookingConfig>((ref) async {
+  final doc = await ref.watch(firestoreProvider).collection('config').doc('booking').get();
+  if (!doc.exists) {
+    return const BookingConfig(
+      slotDurationMinutes: 30,
+      maxVehiclesPerSlot: 15,
+      cancelWindowMinutes: 30,
+      arrivalWindowMinutes: 15,
+      maxBookingsPerVehiclePerDay: 1,
+    );
+  }
+  return BookingConfig.fromMap(doc.data()!);
+});
+
+final userBookingsProvider = StreamProvider<List<BookingModel>>((ref) {
+  final user = ref.watch(authStateProvider).valueOrNull;
+  if (user == null) return Stream.value([]);
+
+  return ref
+  .watch(firestoreProvider)
+  .collection('bookings')
+  .where('userId', isEqualTo: user.uid)
+  .orderBy('slotStart', descending: true)
+  .snapshots()
+  .map((snap) => snap.docs
+    .map((doc) => BookingModel.fromMap(doc.id, doc.data()))
+    .toList());
+});
+
+final slotCountsProvider = FutureProvider.family.autoDispose<Map<String, int>, ({String stationId, DateTime date})>(
+  (ref,params) async {
+    final dayStart = DateTime(params.date.year, params.date.month, params.date.day);
+    final dayEnd = dayStart.add(const Duration(days: 1));
+
+    final snap = await ref
+    .watch(firestoreProvider)
+    .collection('bookings')
+    .where('stationId', isEqualTo: params.stationId)
+    .where('slotStart', isGreaterThanOrEqualTo: Timestamp.fromDate(dayStart))
+    .where('slotStart', isLessThan: Timestamp.fromDate(dayEnd))
+    .where('status', isEqualTo: BookingStatus.upcoming.name)
+    .get();
+
+    final counts = <String, int>{};
+    for (final doc in snap.docs) {
+      final slotStart = (doc['slotStart'] as Timestamp).toDate();
+      final key = '${slotStart.hour.toString().padLeft(2, '0')}:${slotStart.minute.toString().padLeft(2, '0')}';
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    return counts;
+  },
+);
+
+class BookingService {
+  final FirebaseFirestore _firestore;
+  static const _uuid = Uuid();
+
+  BookingService(this._firestore);
+
+  Future<BookingModel> createBooking({
+    required String userId,
+    required String stationId,
+    required String stationName,
+    required String vehicleId,
+    required String vehicleNumber,
+    required String fuelType,
+    required DateTime slotStart,
+  }) async {
+    // Check if vehicle already has a booking this day
+    final dayStart = DateTime(slotStart.year, slotStart.month, slotStart.day);
+    final dayEnd = dayStart.add(const Duration(days: 1));
+    final existing = await _firestore
+        .collection('bookings')
+        .where('vehicleId', isEqualTo: vehicleId)
+        .where('slotStart', isGreaterThanOrEqualTo: Timestamp.fromDate(dayStart))
+        .where('slotStart', isLessThan: Timestamp.fromDate(dayEnd))
+        .where('status', isEqualTo: BookingStatus.upcoming.name)
+        .get();
+    if (existing.docs.isNotEmpty) {
+      throw Exception('This vehicle already has a booking today');
+    }
+
+    final docRef = _firestore.collection('bookings').doc();
+    final booking = BookingModel(
+      id: docRef.id,
+      userId: userId,
+      stationId: stationId,
+      stationName: stationName,
+      vehicleId: vehicleId,
+      vehicleNumber: vehicleNumber,
+      fuelType: fuelType,
+      slotStart: slotStart,
+      status: BookingStatus.upcoming,
+      qrToken: _uuid.v4(),
+      createdAt: DateTime.now(),
+    );
+    await docRef.set(booking.toMap());
+    return booking;
+  }
+
+  Future<void> cancelBooking(String bookingId) async {
+    await _firestore.collection('bookings').doc(bookingId).update({
+      'status': BookingStatus.cancelled.name,
+    });
+  }
+
+  Future<void> scanBooking({
+    required String bookingId,
+    required String attendantId,
+  }) async {
+    await _firestore.collection('bookings').doc(bookingId).update({
+      'qrUsed': true,
+      'scannedBy': attendantId,
+      'scannedAt': Timestamp.fromDate(DateTime.now()),
+      'status': BookingStatus.completed.name,
+    });
+  }
+
+  Future<BookingModel?> findByQrToken(String qrToken) async {
+    final snap = await _firestore
+      .collection('bookings')
+      .where('qrToken', isEqualTo: qrToken)
+      .limit(1)
+      .get();
+    if (snap.docs.isEmpty) return null;
+    return BookingModel.fromMap(snap.docs.first.id, snap.docs.first.data());
+  }
+}
+
+final bookingServiceProvider = Provider((ref) {
+  return BookingService(ref.watch(firestoreProvider));
+});

--- a/lib/features/booking/screens/booking_confirmation_screen.dart
+++ b/lib/features/booking/screens/booking_confirmation_screen.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import '../../../core/constants/app_colors.dart';
+import '../models/booking_model.dart';
+
+class BookingConfirmationScreen extends StatelessWidget {
+  final BookingModel booking;
+  final Duration slotDuration;
+  const BookingConfirmationScreen({super.key, required this.booking, required this.slotDuration});
+
+  @override
+  Widget build(BuildContext context) {
+    final months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    final dt = booking.slotStart;
+    final dateStr = '${dt.day} ${months[dt.month - 1]} ${dt.year}';
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Column(
+            children: [
+              const Spacer(flex: 2),
+              Container(
+                width: 80, height: 80,
+                decoration: BoxDecoration(
+                  gradient: const LinearGradient(colors: [AppColors.primary, AppColors.primaryLight]),
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                child: const Icon(Icons.check_rounded, color: Colors.white, size: 40),
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                'Booking Confirmed!',
+                style: TextStyle(fontSize: 22, fontWeight: FontWeight.w800, color: AppColors.textPrimary),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Your slot at ${booking.stationName} has been reserved.',
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 14, color: AppColors.textSecondary, height: 1.4),
+              ),
+              const SizedBox(height: 32),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(24),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(20),
+                  border: Border.all(color: AppColors.divider),
+                ),
+                child: Column(
+                  children: [
+                    QrImageView(
+                      data: booking.qrToken,
+                      version: QrVersions.auto,
+                      size: 160,
+                      eyeStyle: const QrEyeStyle(color: AppColors.primaryDark, eyeShape: QrEyeShape.circle),
+                      dataModuleStyle: const QrDataModuleStyle(color: AppColors.primary, dataModuleShape: QrDataModuleShape.circle),
+                    ),
+                    const SizedBox(height: 20),
+                    _SummaryLine(label: 'Date', value: dateStr),
+                    _SummaryLine(label: 'Time', value: booking.slotTimeLabel(slotDuration)),
+                    _SummaryLine(label: 'Vehicle', value: booking.vehicleNumber),
+                    _SummaryLine(label: 'Fuel', value: '${booking.fuelType[0].toUpperCase()}${booking.fuelType.substring(1)}', showDivider: false),
+                  ],
+                ),
+              ),
+              const Spacer(flex: 3),
+              SizedBox(
+                width: double.infinity,
+                height: 52,
+                child: ElevatedButton(
+                  onPressed: () => context.go('/home'),
+                  child: const Text('Back to Home', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700)),
+                ),
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                height: 52,
+                child: OutlinedButton(
+                  onPressed: () => context.go('/my-bookings'),
+                  style: OutlinedButton.styleFrom(
+                    side: const BorderSide(color: AppColors.primary),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                  ),
+                  child: const Text('View My Bookings', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700)),
+                ),
+              ),
+              const SizedBox(height: 32),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryLine extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool showDivider;
+
+  const _SummaryLine({required this.label, required this.value, this.showDivider = true});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(label, style: const TextStyle(fontSize: 14, color: AppColors.textSecondary)),
+              Text(value, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: AppColors.textPrimary)),
+            ],
+          ),
+        ),
+        if (showDivider)
+          Divider(height: 1, color: AppColors.divider.withValues(alpha: 0.5)),
+      ],
+    );
+  }
+}

--- a/lib/features/booking/screens/booking_detail_screen.dart
+++ b/lib/features/booking/screens/booking_detail_screen.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import '../../../core/constants/app_colors.dart';
+import '../models/booking_model.dart';
+import '../providers/booking_provider.dart';
+
+class BookingDetailScreen extends ConsumerWidget {
+  final BookingModel booking;
+  const BookingDetailScreen({super.key, required this.booking});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final configAsync = ref.watch(bookingConfigProvider);
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: configAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator(color: AppColors.primary)),
+        error: (e, _) => Center(child: Text('$e')),
+        data: (cfg) => Column(
+          children: [
+            Container(
+              width: double.infinity,
+              padding: EdgeInsets.only(
+                top: MediaQuery.of(context).padding.top + 12,
+                bottom: 24, left: 24, right: 24,
+              ),
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [AppColors.primaryDark, AppColors.primary, AppColors.primaryLight],
+                ),
+                borderRadius: BorderRadius.only(
+                  bottomLeft: Radius.circular(32),
+                  bottomRight: Radius.circular(32),
+                ),
+              ),
+              child: Row(
+                children: [
+                  GestureDetector(
+                    onTap: () => context.pop(),
+                    child: Container(
+                      width: 40, height: 40,
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Icon(Icons.arrow_back_rounded, color: Colors.white, size: 20),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  const Text(
+                    'Booking Details',
+                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.w800, color: Colors.white),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  children: [
+                    // QR section
+                    if (booking.status == BookingStatus.upcoming)
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(24),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(20),
+                          border: Border.all(color: AppColors.divider),
+                        ),
+                        child: Column(
+                          children: [
+                            const Text(
+                              'Show this QR at the station',
+                              style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: AppColors.textSecondary),
+                            ),
+                            const SizedBox(height: 16),
+                            QrImageView(
+                              data: booking.qrToken,
+                              version: QrVersions.auto,
+                              size: 200,
+                              eyeStyle: const QrEyeStyle(color: AppColors.primaryDark, eyeShape: QrEyeShape.circle),
+                              dataModuleStyle: const QrDataModuleStyle(color: AppColors.primary, dataModuleShape: QrDataModuleShape.circle),
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              booking.qrUsed ? 'QR Already Used' : 'Valid for this booking only',
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: booking.qrUsed ? AppColors.error : AppColors.textLight,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    if (booking.status == BookingStatus.upcoming)
+                      const SizedBox(height: 20),
+
+                    // Booking info card
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(20),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(color: AppColors.divider),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          _InfoRow(icon: Icons.local_gas_station_rounded, label: 'Station', value: booking.stationName),
+                          _InfoRow(icon: Icons.calendar_today_rounded, label: 'Date', value: _formatDate(booking.slotStart)),
+                          _InfoRow(icon: Icons.access_time_rounded, label: 'Time Slot', value: booking.slotTimeLabel(cfg.slotDuration)),
+                          _InfoRow(icon: Icons.directions_car_rounded, label: 'Vehicle', value: booking.vehicleNumber),
+                          _InfoRow(icon: Icons.water_drop_rounded, label: 'Fuel Type', value: '${booking.fuelType[0].toUpperCase()}${booking.fuelType.substring(1)}'),
+                          _InfoRow(
+                            icon: Icons.info_outline_rounded,
+                            label: 'Status',
+                            value: _statusLabel(booking.status),
+                            valueColor: _statusColor(booking.status),
+                            isLast: true,
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+
+                    // Cancel button for upcoming bookings
+                    if (booking.status == BookingStatus.upcoming)
+                      SizedBox(
+                        width: double.infinity,
+                        height: 50,
+                        child: OutlinedButton(
+                          onPressed: () => _showCancelDialog(context, ref),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: AppColors.error,
+                            side: const BorderSide(color: AppColors.error),
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                          ),
+                          child: const Text('Cancel Booking', style: TextStyle(fontWeight: FontWeight.w700, fontSize: 15)),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showCancelDialog(BuildContext context, WidgetRef ref) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Cancel Booking?'),
+        content: const Text('This action cannot be undone. Your time slot will be released for others.'),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Keep', style: TextStyle(color: AppColors.textSecondary)),
+          ),
+          TextButton(
+            onPressed: () async {
+              Navigator.pop(ctx);
+              await ref.read(bookingServiceProvider).cancelBooking(booking.id);
+              if (context.mounted) context.pop();
+            },
+            child: const Text('Cancel Booking', style: TextStyle(color: AppColors.error, fontWeight: FontWeight.w600)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime dt) {
+    final days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+    final months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    return '${days[dt.weekday - 1]}, ${dt.day} ${months[dt.month - 1]} ${dt.year}';
+  }
+
+  String _statusLabel(BookingStatus s) {
+    switch (s) {
+      case BookingStatus.upcoming: return 'Upcoming';
+      case BookingStatus.completed: return 'Completed';
+      case BookingStatus.cancelled: return 'Cancelled';
+      case BookingStatus.expired: return 'Expired';
+      case BookingStatus.noShow: return 'No Show';
+    }
+  }
+
+  Color _statusColor(BookingStatus s) {
+    switch (s) {
+      case BookingStatus.upcoming: return AppColors.primary;
+      case BookingStatus.completed: return AppColors.success;
+      case BookingStatus.cancelled: return AppColors.textLight;
+      case BookingStatus.expired: return AppColors.warning;
+      case BookingStatus.noShow: return AppColors.error;
+    }
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color? valueColor;
+  final bool isLast;
+
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.valueColor,
+    this.isLast = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: isLast ? 0 : 16),
+      child: Row(
+        children: [
+          Container(
+            width: 36, height: 36,
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(icon, size: 18, color: AppColors.primary),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: AppColors.textLight, letterSpacing: 0.4)),
+                const SizedBox(height: 2),
+                Text(value, style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: valueColor ?? AppColors.textPrimary)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/booking/screens/my_bookings_screen.dart
+++ b/lib/features/booking/screens/my_bookings_screen.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/constants/app_colors.dart';
+import '../models/booking_model.dart';
+import '../providers/booking_provider.dart';
+
+class MyBookingsScreen extends ConsumerWidget {
+  const MyBookingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bookingsAsync = ref.watch(userBookingsProvider);
+    final configAsync = ref.watch(bookingConfigProvider);
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: Column(
+        children: [
+          Container(
+            width: double.infinity,
+            padding: EdgeInsets.only(
+              top: MediaQuery.of(context).padding.top + 12,
+              bottom: 24, left: 24, right: 24,
+            ),
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [AppColors.primaryDark, AppColors.primary, AppColors.primaryLight],
+              ),
+              borderRadius: BorderRadius.only(
+                bottomLeft: Radius.circular(32),
+                bottomRight: Radius.circular(32),
+              ),
+            ),
+            child: const Text(
+              'My Bookings',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w800, color: Colors.white),
+            ),
+          ),
+          Expanded(
+            child: bookingsAsync.when(
+              loading: () => const Center(child: CircularProgressIndicator(color: AppColors.primary)),
+              error: (e, _) => Center(child: Text('Error loading bookings: $e')),
+              data: (bookings) {
+                if (bookings.isEmpty) {
+                  return Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 64, height: 64,
+                          decoration: BoxDecoration(
+                            color: AppColors.primary.withValues(alpha: 0.08),
+                            shape: BoxShape.circle,
+                          ),
+                          child: const Icon(Icons.calendar_today_outlined, size: 32, color: AppColors.primaryLight),
+                        ),
+                        const SizedBox(height: 16),
+                        const Text('No bookings yet', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: AppColors.textPrimary)),
+                        const SizedBox(height: 6),
+                        const Text('Book a fuel slot from the map', style: TextStyle(fontSize: 14, color: AppColors.textSecondary)),
+                      ],
+                    ),
+                  );
+                }
+
+                final upcoming = bookings.where((b) => b.status == BookingStatus.upcoming).toList();
+                final past = bookings.where((b) => b.status != BookingStatus.upcoming).toList();
+
+                return configAsync.when(
+                  loading: () => const Center(child: CircularProgressIndicator()),
+                  error: (e, _) => Center(child: Text('$e')),
+                  data: (cfg) => ListView(
+                    padding: const EdgeInsets.all(24),
+                    children: [
+                      if (upcoming.isNotEmpty) ...[
+                        const Text('Upcoming', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700, color: AppColors.textPrimary)),
+                        const SizedBox(height: 12),
+                        ...upcoming.map((b) => _BookingCard(booking: b, config: cfg)),
+                      ],
+                      if (upcoming.isNotEmpty && past.isNotEmpty)
+                        const SizedBox(height: 24),
+                      if (past.isNotEmpty) ...[
+                        const Text('Past', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700, color: AppColors.textPrimary)),
+                        const SizedBox(height: 12),
+                        ...past.map((b) => _BookingCard(booking: b, config: cfg)),
+                      ],
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BookingCard extends StatelessWidget {
+  final BookingModel booking;
+  final BookingConfig config;
+
+  const _BookingCard({required this.booking, required this.config});
+
+  Color get _statusColor {
+    switch (booking.status) {
+      case BookingStatus.upcoming: return AppColors.primary;
+      case BookingStatus.completed: return AppColors.success;
+      case BookingStatus.cancelled: return AppColors.textLight;
+      case BookingStatus.expired: return AppColors.warning;
+      case BookingStatus.noShow: return AppColors.error;
+    }
+  }
+
+  String get _statusText {
+    switch (booking.status) {
+      case BookingStatus.upcoming: return 'Upcoming';
+      case BookingStatus.completed: return 'Completed';
+      case BookingStatus.cancelled: return 'Cancelled';
+      case BookingStatus.expired: return 'Expired';
+      case BookingStatus.noShow: return 'No Show';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final date = booking.slotStart;
+    final dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    final monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    final dateStr = '${dayNames[date.weekday - 1]}, ${date.day} ${monthNames[date.month - 1]}';
+
+    return GestureDetector(
+      onTap: () => context.push('/booking-detail', extra: booking),
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: AppColors.divider),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 50, height: 50,
+              decoration: BoxDecoration(
+                color: _statusColor.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Icon(Icons.local_gas_station_rounded, color: _statusColor, size: 24),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    booking.stationName,
+                    style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15, color: AppColors.textPrimary),
+                    maxLines: 1, overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    '$dateStr · ${booking.slotTimeLabel(config.slotDuration)}',
+                    style: const TextStyle(fontSize: 13, color: AppColors.textSecondary),
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                        decoration: BoxDecoration(
+                          color: _statusColor.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(_statusText, style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: _statusColor)),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(booking.vehicleNumber, style: const TextStyle(fontSize: 12, color: AppColors.textLight)),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.chevron_right_rounded, color: AppColors.textLight),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/booking/screens/station_booking_screen.dart
+++ b/lib/features/booking/screens/station_booking_screen.dart
@@ -1,0 +1,383 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../auth/providers/auth_provider.dart';
+import '../../auth/models/vehicle_model.dart';
+import '../../map/models/station_model.dart';
+import '../providers/booking_provider.dart';
+
+class StationBookingScreen extends ConsumerStatefulWidget {
+  final StationModel station;
+  const StationBookingScreen({super.key, required this.station});
+
+  @override
+  ConsumerState<StationBookingScreen> createState() => _StationBookingScreenState();
+}
+
+class _StationBookingScreenState extends ConsumerState<StationBookingScreen> {
+  DateTime _selectedDate = DateTime.now();
+  String? _selectedSlot;
+  VehicleModel? _selectedVehicle;
+  bool _isBooking = false;
+
+  List<DateTime> get _dates =>
+      List.generate(7, (i) => DateTime.now().add(Duration(days: i)));
+
+  List<String> _generateSlots(int durationMinutes) {
+    final open = _parseTime(widget.station.openTime);
+    final close = _parseTime(widget.station.closeTime);
+    final slots = <String>[];
+    var current = open;
+    while (current + durationMinutes <= close) {
+      final h = (current ~/ 60).toString().padLeft(2, '0');
+      final m = (current % 60).toString().padLeft(2, '0');
+      slots.add('$h:$m');
+      current += durationMinutes;
+    }
+    return slots;
+  }
+
+  int _parseTime(String time) {
+    final parts = time.split(':');
+    return int.parse(parts[0]) * 60 + int.parse(parts[1]);
+  }
+
+  Future<void> _book() async {
+    final user = ref.read(authStateProvider).valueOrNull;
+    if (user == null || _selectedVehicle == null || _selectedSlot == null) return;
+
+    setState(() => _isBooking = true);
+    try {
+      final parts = _selectedSlot!.split(':');
+      final slotStart = DateTime(
+        _selectedDate.year, _selectedDate.month, _selectedDate.day,
+        int.parse(parts[0]), int.parse(parts[1]),
+      );
+
+      final booking = await ref.read(bookingServiceProvider).createBooking(
+        userId: user.uid,
+        stationId: widget.station.id,
+        stationName: widget.station.name,
+        vehicleId: _selectedVehicle!.id,
+        vehicleNumber: _selectedVehicle!.vehicleNumber,
+        fuelType: _selectedVehicle!.fuelType.name,
+        slotStart: slotStart,
+      );
+
+      if (mounted) {
+        final cfg = ref.read(bookingConfigProvider).valueOrNull;
+        context.go('/booking-confirmed', extra: {
+          'booking': booking,
+          'slotDuration': cfg?.slotDuration ?? const Duration(minutes: 30),
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        final isVehicleBooked = e.toString().contains('already has a booking');
+        showDialog(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: Text(isVehicleBooked ? 'Vehicle Already Booked' : 'Booking Failed'),
+            content: Text(isVehicleBooked
+                ? 'This vehicle already has a fuel slot booked for today. Each vehicle is limited to one booking per day.'
+                : 'Something went wrong while creating your booking. Please try again later.'),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isBooking = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final config = ref.watch(bookingConfigProvider);
+    final vehicles = ref.watch(vehiclesProvider);
+    final slotCounts = ref.watch(slotCountsProvider(
+      (stationId: widget.station.id, date: _selectedDate),
+    ));
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: config.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (cfg) {
+          final slots = _generateSlots(cfg.slotDurationMinutes);
+          return Column(
+            children: [
+              // Header
+              Container(
+                width: double.infinity,
+                padding: EdgeInsets.only(
+                  top: MediaQuery.of(context).padding.top + 12,
+                  bottom: 20, left: 24, right: 24,
+                ),
+                decoration: const BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [AppColors.primaryDark, AppColors.primary, AppColors.primaryLight],
+                  ),
+                  borderRadius: BorderRadius.only(
+                    bottomLeft: Radius.circular(32),
+                    bottomRight: Radius.circular(32),
+                  ),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    GestureDetector(
+                      onTap: () => context.pop(),
+                      child: Container(
+                        width: 40, height: 40,
+                        decoration: BoxDecoration(
+                          color: Colors.white.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: const Icon(Icons.arrow_back_rounded, color: Colors.white, size: 20),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      widget.station.name,
+                      style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w800, color: Colors.white),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      widget.station.address,
+                      style: TextStyle(fontSize: 14, color: Colors.white.withValues(alpha: 0.7)),
+                    ),
+                  ],
+                ),
+              ),
+
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Date selector
+                      const Text(
+                        'Select Date',
+                        style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700, color: AppColors.textPrimary),
+                      ),
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        height: 80,
+                        child: ListView.separated(
+                          scrollDirection: Axis.horizontal,
+                          itemCount: _dates.length,
+                          separatorBuilder: (_, _) => const SizedBox(width: 10),
+                          itemBuilder: (_, i) {
+                            final date = _dates[i];
+                            final isSelected = date.day == _selectedDate.day && date.month == _selectedDate.month;
+                            return GestureDetector(
+                              onTap: () => setState(() {
+                                _selectedDate = date;
+                                _selectedSlot = null;
+                              }),
+                              child: Container(
+                                width: 60,
+                                decoration: BoxDecoration(
+                                  color: isSelected ? AppColors.primary : Colors.white,
+                                  borderRadius: BorderRadius.circular(16),
+                                  border: Border.all(color: isSelected ? AppColors.primary : AppColors.divider),
+                                ),
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][date.weekday - 1],
+                                      style: TextStyle(
+                                        fontSize: 12, fontWeight: FontWeight.w600,
+                                        color: isSelected ? Colors.white : AppColors.textSecondary,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 4),
+                                    Text(
+                                      '${date.day}',
+                                      style: TextStyle(
+                                        fontSize: 20, fontWeight: FontWeight.w800,
+                                        color: isSelected ? Colors.white : AppColors.textPrimary,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Time slots
+                      const Text(
+                        'Select Time Slot',
+                        style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700, color: AppColors.textPrimary),
+                      ),
+                      const SizedBox(height: 12),
+                      slotCounts.when(
+                        loading: () => const Center(child: CircularProgressIndicator()),
+                        error: (e, _) => Text('Error: $e'),
+                        data: (counts) => Wrap(
+                          spacing: 10,
+                          runSpacing: 10,
+                          children: slots.map((slot) {
+                            final count = counts[slot] ?? 0;
+                            final isFull = count >= cfg.maxVehiclesPerSlot;
+                            final isSelected = _selectedSlot == slot;
+                            final slotParts = slot.split(':');
+                            final slotDateTime = DateTime(
+                              _selectedDate.year, _selectedDate.month, _selectedDate.day,
+                              int.parse(slotParts[0]), int.parse(slotParts[1]),
+                            );
+                            final isPast = slotDateTime.isBefore(DateTime.now());
+                            final isDisabled = isFull || isPast;
+                            return GestureDetector(
+                              onTap: isDisabled ? null : () => setState(() => _selectedSlot = slot),
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                                decoration: BoxDecoration(
+                                  color: isPast
+                                      ? AppColors.divider.withValues(alpha: 0.5)
+                                      : isFull
+                                          ? AppColors.error.withValues(alpha: 0.1)
+                                          : isSelected ? AppColors.primary : AppColors.success.withValues(alpha: 0.1),
+                                  borderRadius: BorderRadius.circular(12),
+                                  border: Border.all(
+                                    color: isPast
+                                        ? AppColors.divider
+                                        : isFull
+                                            ? AppColors.error
+                                            : isSelected ? AppColors.primary : AppColors.success,
+                                  ),
+                                ),
+                                child: Column(
+                                  children: [
+                                    Text(
+                                      slot,
+                                      style: TextStyle(
+                                        fontSize: 14, fontWeight: FontWeight.w700,
+                                        color: isPast
+                                            ? AppColors.textLight
+                                            : isFull
+                                                ? AppColors.error
+                                                : isSelected ? Colors.white : AppColors.success,
+                                      ),
+                                    ),
+                                    Text(
+                                      isPast ? 'Passed' : isFull ? 'Full' : '${cfg.maxVehiclesPerSlot - count} left',
+                                      style: TextStyle(
+                                        fontSize: 11,
+                                        color: isPast
+                                            ? AppColors.textLight
+                                            : isFull
+                                                ? AppColors.error
+                                                : isSelected ? Colors.white.withValues(alpha: 0.7) : AppColors.textSecondary,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
+                          }).toList(),
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Vehicle selector
+                      const Text(
+                        'Select Vehicle',
+                        style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700, color: AppColors.textPrimary),
+                      ),
+                      const SizedBox(height: 12),
+                      vehicles.when(
+                        loading: () => const Center(child: CircularProgressIndicator()),
+                        error: (e, _) => Text('Error: $e'),
+                        data: (list) => Column(
+                          children: list.map((v) {
+                            final isSelected = _selectedVehicle?.id == v.id;
+                            return GestureDetector(
+                              onTap: () => setState(() => _selectedVehicle = v),
+                              child: Container(
+                                width: double.infinity,
+                                margin: const EdgeInsets.only(bottom: 10),
+                                padding: const EdgeInsets.all(16),
+                                decoration: BoxDecoration(
+                                  color: isSelected ? AppColors.primary.withValues(alpha: 0.08) : Colors.white,
+                                  borderRadius: BorderRadius.circular(14),
+                                  border: Border.all(color: isSelected ? AppColors.primary : AppColors.divider),
+                                ),
+                                child: Row(
+                                  children: [
+                                    Icon(Icons.directions_car_rounded,
+                                      color: isSelected ? AppColors.primary : AppColors.textSecondary,
+                                    ),
+                                    const SizedBox(width: 12),
+                                    Expanded(
+                                      child: Column(
+                                        crossAxisAlignment: CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            v.nickname.isNotEmpty ? v.nickname : v.vehicleNumber,
+                                            style: TextStyle(
+                                              fontSize: 15, fontWeight: FontWeight.w700,
+                                              color: isSelected ? AppColors.primary : AppColors.textPrimary,
+                                            ),
+                                          ),
+                                          Text(
+                                            '${v.vehicleNumber} · ${v.fuelType.name[0].toUpperCase()}${v.fuelType.name.substring(1)}',
+                                            style: const TextStyle(fontSize: 13, color: AppColors.textSecondary),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    if (isSelected)
+                                      const Icon(Icons.check_circle_rounded, color: AppColors.primary),
+                                  ],
+                                ),
+                              ),
+                            );
+                          }).toList(),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+
+              // Book button
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 0, 24, 32),
+                child: SizedBox(
+                  width: double.infinity,
+                  height: 52,
+                  child: ElevatedButton(
+                    onPressed: (_selectedSlot != null && _selectedVehicle != null && !_isBooking)
+                        ? _book : null,
+                    child: _isBooking
+                        ? const SizedBox(
+                            width: 20, height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                          )
+                        : const Text('Confirm Booking', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700)),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/screens/home_screen.dart
+++ b/lib/features/dashboard/screens/home_screen.dart
@@ -1,9 +1,11 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/constants/app_colors.dart';
-import '../../auth/models/vehicle_model.dart';
 import '../../auth/providers/auth_provider.dart';
+import '../models/quota_model.dart';
+import '../providers/quota_provider.dart';
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
@@ -11,7 +13,8 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final userAsync = ref.watch(userProvider);
-    final vehiclesAsync = ref.watch(vehiclesProvider);
+    final quotas = ref.watch(quotasProvider);
+    final summary = ref.watch(quotaSummaryProvider);
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -39,7 +42,7 @@ class HomeScreen extends ConsumerWidget {
 
           return Column(
             children: [
-              // Blue header
+              // Header with greeting + quota ring
               Container(
                 width: double.infinity,
                 padding: EdgeInsets.only(
@@ -108,12 +111,9 @@ class HomeScreen extends ConsumerWidget {
                         ),
                       ],
                     ),
-                    const SizedBox(height: 12),
+                    const SizedBox(height: 8),
                     Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 5,
-                      ),
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
                       decoration: BoxDecoration(
                         color: Colors.white.withValues(alpha: 0.15),
                         borderRadius: BorderRadius.circular(20),
@@ -127,113 +127,77 @@ class HomeScreen extends ConsumerWidget {
                         ),
                       ),
                     ),
+                    const SizedBox(height: 24),
+                    // Quota ring
+                    Center(
+                      child: _QuotaRing(
+                        usagePercent: summary.usagePercent,
+                        remaining: summary.totalRemaining,
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    // Summary stats
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        _HeaderStat(label: 'Weekly Limit', value: '${summary.totalLimit.toStringAsFixed(0)}L'),
+                        Container(width: 1, height: 32, color: Colors.white.withValues(alpha: 0.2)),
+                        _HeaderStat(label: 'Used', value: '${summary.totalUsed.toStringAsFixed(1)}L'),
+                        Container(width: 1, height: 32, color: Colors.white.withValues(alpha: 0.2)),
+                        _HeaderStat(label: 'Vehicles', value: '${summary.vehicleCount}'),
+                      ],
+                    ),
                   ],
                 ),
               ),
+
+              // Vehicle quota cards
               Expanded(
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.fromLTRB(24, 24, 24, 24),
-                  child: Column(
-                    children: [
-                      Row(
-                        children: [
-                          _QuickAction(
-                            icon: Icons.water_drop_rounded,
-                            label: 'My Quota',
-                            onTap: () => context.push('/quota'),
-                          ),
-                          const SizedBox(width: 12),
-                          _QuickAction(
-                            icon: Icons.calendar_today_rounded,
-                            label: 'Find Station',
-                            onTap: () => context.push('/map'),
-                          ),
-                          const SizedBox(width: 12),
-                          _QuickAction(
-                            icon: Icons.qr_code_rounded,
-                            label: 'My QR',
-                            onTap: () {},
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 28),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          const Text(
-                            'My Vehicles',
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.w700,
-                              color: AppColors.textPrimary,
-                            ),
-                          ),
-                          GestureDetector(
-                            onTap: () => context.push(
-                              '/add-vehicle',
-                              extra: {'uid': user.uid, 'isFirstTime': false},
-                            ),
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 14,
-                                vertical: 8,
-                              ),
+                child: quotas.isEmpty
+                    ? Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Container(
+                              width: 64, height: 64,
                               decoration: BoxDecoration(
-                                color: AppColors.primary.withValues(
-                                  alpha: 0.08,
-                                ),
-                                borderRadius: BorderRadius.circular(20),
+                                color: AppColors.primary.withValues(alpha: 0.08),
+                                shape: BoxShape.circle,
                               ),
-                              child: const Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Icon(
-                                    Icons.add_rounded,
-                                    size: 16,
-                                    color: AppColors.primary,
-                                  ),
-                                  SizedBox(width: 4),
-                                  Text(
-                                    'Add Vehicle',
-                                    style: TextStyle(
-                                      fontSize: 13,
-                                      fontWeight: FontWeight.w600,
-                                      color: AppColors.primary,
-                                    ),
-                                  ),
-                                ],
-                              ),
+                              child: const Icon(Icons.local_gas_station_outlined, size: 32, color: AppColors.primaryLight),
                             ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 14),
-                      vehiclesAsync.when(
-                        loading: () => const Center(
-                          child: CircularProgressIndicator(
-                            color: AppColors.primary,
-                          ),
+                            const SizedBox(height: 16),
+                            const Text('No quota data yet', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: AppColors.textPrimary)),
+                            const SizedBox(height: 6),
+                            const Text('Register a vehicle to view your fuel quota', style: TextStyle(fontSize: 14, color: AppColors.textSecondary)),
+                            const SizedBox(height: 20),
+                            ElevatedButton(
+                              onPressed: () => context.push('/add-vehicle', extra: {'uid': user.uid, 'isFirstTime': false}),
+                              child: const Text('Register a Vehicle'),
+                            ),
+                          ],
                         ),
-                        error: (e, _) => Text('Error: $e'),
-                        data: (vehicles) {
-                          if (vehicles.isEmpty) {
-                            return _EmptyVehiclesCard(
-                              onAdd: () => context.push(
-                                '/add-vehicle',
-                                extra: {'uid': user.uid, 'isFirstTime': false},
+                      )
+                    : SingleChildScrollView(
+                        padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            if (quotas.isNotEmpty)
+                              _WeekInfoCard(
+                                weekStart: quotas.first.weekStart,
+                                weekEnd: quotas.first.weekEnd,
                               ),
-                            );
-                          }
-                          return Column(
-                            children: vehicles
-                                .map((v) => _VehicleListItem(vehicle: v))
-                                .toList(),
-                          );
-                        },
+                            const SizedBox(height: 20),
+                            const Text(
+                              'Vehicle Quotas',
+                              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: AppColors.textPrimary),
+                            ),
+                            const SizedBox(height: 14),
+                            ...quotas.map((q) => _VehicleQuotaCard(quota: q)),
+                          ],
+                        ),
                       ),
-                    ],
-                  ),
-                ),
               ),
             ],
           );
@@ -251,60 +215,55 @@ class HomeScreen extends ConsumerWidget {
 
   String _roleLabel(String role) {
     switch (role) {
-      case 'vehicleOwner':
-        return 'Vehicle Owner';
-      case 'stationAttendant':
-        return 'Station Attendant';
-      case 'governmentAdmin':
-        return 'Government Admin';
-      default:
-        return role;
+      case 'vehicleOwner': return 'Vehicle Owner';
+      case 'stationAttendant': return 'Station Attendant';
+      case 'governmentAdmin': return 'Government Admin';
+      default: return role;
     }
   }
 }
 
-class _QuickAction extends StatelessWidget {
-  final IconData icon;
+class _HeaderStat extends StatelessWidget {
   final String label;
-  final VoidCallback onTap;
+  final String value;
 
-  const _QuickAction({
-    required this.icon,
-    required this.label,
-    required this.onTap,
-  });
+  const _HeaderStat({required this.label, required this.value});
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: GestureDetector(
-        onTap: onTap,
-        child: Container(
-          padding: const EdgeInsets.symmetric(vertical: 20),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: AppColors.divider),
-          ),
+    return Column(
+      children: [
+        Text(value, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w800, color: Colors.white)),
+        const SizedBox(height: 4),
+        Text(label, style: TextStyle(fontSize: 12, fontWeight: FontWeight.w500, color: Colors.white.withValues(alpha: 0.6))),
+      ],
+    );
+  }
+}
+
+class _QuotaRing extends StatelessWidget {
+  final double usagePercent;
+  final double remaining;
+
+  const _QuotaRing({required this.usagePercent, required this.remaining});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 140, height: 140,
+      child: CustomPaint(
+        painter: _RingPainter(usagePercent: usagePercent),
+        child: Center(
           child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              Container(
-                width: 44,
-                height: 44,
-                decoration: BoxDecoration(
-                  color: AppColors.primary.withValues(alpha: 0.08),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Icon(icon, color: AppColors.primary, size: 22),
-              ),
-              const SizedBox(height: 10),
               Text(
-                label,
-                style: const TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.textPrimary,
-                ),
+                '${remaining.toStringAsFixed(0)}L',
+                style: const TextStyle(fontSize: 28, fontWeight: FontWeight.w800, color: Colors.white),
+              ),
+              Text(
+                'remaining',
+                style: TextStyle(fontSize: 12, color: Colors.white.withValues(alpha: 0.6)),
               ),
             ],
           ),
@@ -314,199 +273,104 @@ class _QuickAction extends StatelessWidget {
   }
 }
 
-class _VehicleListItem extends StatelessWidget {
-  final VehicleModel vehicle;
+class _RingPainter extends CustomPainter {
+  final double usagePercent;
 
-  const _VehicleListItem({required this.vehicle});
+  _RingPainter({required this.usagePercent});
 
-  void _showVehicleDetails(BuildContext context) {
-    showModalBottomSheet(
-      context: context,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-      ),
-      builder: (ctx) => Padding(
-        padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              width: 40,
-              height: 4,
-              decoration: BoxDecoration(
-                color: AppColors.divider,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-            const SizedBox(height: 20),
-            Container(
-              width: 64,
-              height: 64,
-              decoration: BoxDecoration(
-                gradient: const LinearGradient(
-                  colors: [AppColors.primary, AppColors.primaryLight],
-                ),
-                borderRadius: BorderRadius.circular(18),
-              ),
-              child: const Icon(
-                Icons.directions_car_rounded,
-                color: Colors.white,
-                size: 32,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              vehicle.nickname.isNotEmpty
-                  ? vehicle.nickname
-                  : vehicle.vehicleNumber,
-              style: const TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.w700,
-                color: AppColors.textPrimary,
-              ),
-            ),
-            const SizedBox(height: 20),
-            _DetailRow(
-              icon: Icons.confirmation_number_outlined,
-              label: 'Vehicle Number',
-              value: vehicle.vehicleNumber,
-            ),
-            _DetailRow(
-              icon: Icons.pin_outlined,
-              label: 'Chassis Number',
-              value: vehicle.chassisNumber,
-            ),
-            _DetailRow(
-              icon: Icons.local_gas_station_outlined,
-              label: 'Fuel Type',
-              value: vehicle.fuelType.name[0].toUpperCase() +
-                  vehicle.fuelType.name.substring(1),
-            ),
-            if (vehicle.nickname.isNotEmpty)
-              _DetailRow(
-                icon: Icons.label_outlined,
-                label: 'Nickname',
-                value: vehicle.nickname,
-              ),
-          ],
-        ),
-      ),
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width / 2 - 8;
+    const strokeWidth = 20.0;
+
+    final bgPaint = Paint()
+      ..color = Colors.white.withValues(alpha: 0.15)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawCircle(center, radius, bgPaint);
+
+    final progressPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    if (usagePercent >= 0.9) {
+      progressPaint.color = AppColors.error;
+    } else if (usagePercent >= 0.7) {
+      progressPaint.color = AppColors.warning;
+    } else {
+      progressPaint.color = AppColors.success;
+    }
+
+    final sweepAngle = 2 * pi * (1 - usagePercent);
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      -pi / 2,
+      sweepAngle,
+      false,
+      progressPaint,
     );
   }
 
   @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => _showVehicleDetails(context),
-      child: Container(
-        margin: const EdgeInsets.only(bottom: 12),
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: AppColors.divider),
-        ),
-        child: Row(
-          children: [
-            Container(
-              width: 50,
-              height: 50,
-              decoration: BoxDecoration(
-                gradient: const LinearGradient(
-                  colors: [AppColors.primary, AppColors.primaryLight],
-                ),
-                borderRadius: BorderRadius.circular(14),
-              ),
-              child: const Icon(
-                Icons.directions_car_rounded,
-                color: Colors.white,
-                size: 24,
-              ),
-            ),
-            const SizedBox(width: 14),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    vehicle.nickname.isNotEmpty
-                        ? vehicle.nickname
-                        : vehicle.vehicleNumber,
-                    style: const TextStyle(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 15,
-                      color: AppColors.textPrimary,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    '${vehicle.vehicleNumber} \u00B7 ${vehicle.fuelType.name[0].toUpperCase()}${vehicle.fuelType.name.substring(1)}',
-                    style: const TextStyle(
-                      fontSize: 13,
-                      color: AppColors.textSecondary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const Icon(Icons.chevron_right_rounded, color: AppColors.textLight),
-          ],
-        ),
-      ),
-    );
-  }
+  bool shouldRepaint(covariant _RingPainter oldDelegate) =>
+      oldDelegate.usagePercent != usagePercent;
 }
 
-class _DetailRow extends StatelessWidget {
-  final IconData icon;
-  final String label;
-  final String value;
+class _WeekInfoCard extends StatelessWidget {
+  final DateTime weekStart;
+  final DateTime weekEnd;
 
-  const _DetailRow({
-    required this.icon,
-    required this.label,
-    required this.value,
-  });
+  const _WeekInfoCard({required this.weekStart, required this.weekEnd});
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 14),
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    final startStr = '${weekStart.day} ${months[weekStart.month - 1]}';
+    final endStr = '${weekEnd.day} ${months[weekEnd.month - 1]}';
+    final daysLeft = weekEnd.difference(DateTime.now()).inDays.clamp(0, 7);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.accent.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.accent.withValues(alpha: 0.15)),
+      ),
       child: Row(
         children: [
           Container(
-            width: 36,
-            height: 36,
+            width: 44, height: 44,
             decoration: BoxDecoration(
-              color: AppColors.primary.withValues(alpha: 0.08),
-              borderRadius: BorderRadius.circular(10),
+              color: AppColors.accent.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(12),
             ),
-            child: Icon(icon, size: 18, color: AppColors.primary),
+            child: const Icon(Icons.calendar_today_rounded, size: 20, color: AppColors.accent),
           ),
           const SizedBox(width: 14),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  label,
-                  style: const TextStyle(
-                    fontSize: 11,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.textLight,
-                    letterSpacing: 0.5,
-                  ),
-                ),
+                Text('$startStr - $endStr', style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w700, color: AppColors.textPrimary)),
                 const SizedBox(height: 2),
-                Text(
-                  value,
-                  style: const TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.textPrimary,
-                  ),
-                ),
+                const Text('Current quota week', style: TextStyle(fontSize: 13, color: AppColors.textSecondary)),
               ],
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+            decoration: BoxDecoration(
+              color: daysLeft <= 1 ? AppColors.warning.withValues(alpha: 0.1) : AppColors.success.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Text(
+              '$daysLeft days left',
+              style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: daysLeft <= 1 ? AppColors.warning : AppColors.success),
             ),
           ),
         ],
@@ -515,16 +379,32 @@ class _DetailRow extends StatelessWidget {
   }
 }
 
-class _EmptyVehiclesCard extends StatelessWidget {
-  final VoidCallback onAdd;
+class _VehicleQuotaCard extends StatelessWidget {
+  final QuotaModel quota;
 
-  const _EmptyVehiclesCard({required this.onAdd});
+  const _VehicleQuotaCard({required this.quota});
 
   @override
   Widget build(BuildContext context) {
+    final displayName = quota.nickname.isNotEmpty ? quota.nickname : quota.vehicleNumber;
+    final fuelLabel = quota.fuelType[0].toUpperCase() + quota.fuelType.substring(1);
+
+    Color statusColor;
+    String statusLabel;
+    if (quota.isExhausted) {
+      statusColor = AppColors.error;
+      statusLabel = 'Exhausted';
+    } else if (quota.usagePercent >= 0.7) {
+      statusColor = AppColors.warning;
+      statusLabel = 'Low';
+    } else {
+      statusColor = AppColors.success;
+      statusLabel = 'Available';
+    }
+
     return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(32),
+      margin: const EdgeInsets.only(bottom: 14),
+      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(16),
@@ -532,40 +412,85 @@ class _EmptyVehiclesCard extends StatelessWidget {
       ),
       child: Column(
         children: [
-          Container(
-            width: 64,
-            height: 64,
-            decoration: BoxDecoration(
-              color: AppColors.primary.withValues(alpha: 0.08),
-              shape: BoxShape.circle,
-            ),
-            child: const Icon(
-              Icons.directions_car_outlined,
-              size: 32,
-              color: AppColors.primaryLight,
-            ),
+          Row(
+            children: [
+              Container(
+                width: 48, height: 48,
+                decoration: BoxDecoration(
+                  gradient: const LinearGradient(colors: [AppColors.primary, AppColors.primaryLight]),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: const Icon(Icons.directions_car_rounded, color: Colors.white, size: 22),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(displayName, style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15, color: AppColors.textPrimary)),
+                    const SizedBox(height: 3),
+                    Text('${quota.vehicleNumber} \u00B7 $fuelLabel', style: const TextStyle(fontSize: 13, color: AppColors.textSecondary)),
+                  ],
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                decoration: BoxDecoration(
+                  color: statusColor.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Text(statusLabel, style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: statusColor)),
+              ),
+            ],
           ),
           const SizedBox(height: 16),
-          const Text(
-            'No vehicles registered',
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-              color: AppColors.textPrimary,
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: LinearProgressIndicator(
+              value: quota.usagePercent,
+              minHeight: 8,
+              backgroundColor: AppColors.divider,
+              valueColor: AlwaysStoppedAnimation<Color>(statusColor),
             ),
           ),
-          const SizedBox(height: 6),
-          const Text(
-            'Add a vehicle to start booking fuel',
-            style: TextStyle(fontSize: 14, color: AppColors.textSecondary),
-          ),
-          const SizedBox(height: 20),
-          ElevatedButton(
-            onPressed: onAdd,
-            child: const Text('Register a Vehicle'),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _QuotaStat(icon: Icons.local_gas_station_rounded, label: 'Used', value: '${quota.used.toStringAsFixed(1)}L', color: AppColors.textSecondary),
+              _QuotaStat(icon: Icons.water_drop_outlined, label: 'Remaining', value: '${quota.remaining.toStringAsFixed(1)}L', color: statusColor),
+              _QuotaStat(icon: Icons.speed_rounded, label: 'Limit', value: '${quota.weeklyLimit.toStringAsFixed(0)}L', color: AppColors.textSecondary),
+            ],
           ),
         ],
       ),
+    );
+  }
+}
+
+class _QuotaStat extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color color;
+
+  const _QuotaStat({required this.icon, required this.label, required this.value, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: 4),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(value, style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: color)),
+            Text(label, style: const TextStyle(fontSize: 10, color: AppColors.textLight)),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/features/map/screens/map_screen.dart
+++ b/lib/features/map/screens/map_screen.dart
@@ -6,6 +6,7 @@ import '../../../core/constants/app_colors.dart';
 import '../models/station_model.dart';
 import '../providers/station_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:go_router/go_router.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/foundation.dart';
 import 'package:custom_info_window/custom_info_window.dart';
@@ -170,6 +171,11 @@ class _MapScreenState extends ConsumerState<MapScreen> {
           station.location,
     );
         setState(() => _selectedStation = station);
+        _mapController?.animateCamera(
+          CameraUpdate.newLatLng(
+            LatLng(station.location.latitude - 0.02, station.location.longitude),
+          ),
+        );
         },
       );
     }).toSet();
@@ -250,11 +256,6 @@ class _MapScreenState extends ConsumerState<MapScreen> {
                 right: 16,
                 child: Row(
                   children: [
-                    _MapButton(
-                      icon: Icons.arrow_back_rounded,
-                      onTap: () => Navigator.of(context).pop(),
-                    ),
-                    const SizedBox(width: 12),
                     Expanded(
                       child: Container(
                         padding: const EdgeInsets.symmetric(
@@ -546,6 +547,15 @@ class _StationSheet extends StatelessWidget {
             icon: const Icon(Icons.directions_rounded),
             label: const Text('Get Directions'),
             )
+          ),
+          const SizedBox(height: 10),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: () => context.push('/book-station', extra: station),
+              icon: const Icon(Icons.calendar_month_rounded),
+              label: const Text('Book Slot'),
+            ),
           ),
           const SizedBox(height: 16),
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -742,7 +742,7 @@ packages:
     source: hosted
     version: "3.1.5"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   url_launcher: ^6.3.2
   custom_info_window: ^1.0.1
+  uuid: ^4.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Added slot booking system with date/time selection and vehicle picker
- QR code generation per booking using uuid + qr_flutter (package)
- My Bookings screen with upcoming/past sections
- Booking detail screen with QR display and cancel functionality
- Bottom navigation bar (Home, Map, Bookings, Profile)
- Home screen now shows fuel quota dashboard inline
- Business rules (slot duration, max vehicles, cancel window) stored in Firestore config
- Past/full time slots greyed out, duplicate booking prevention